### PR TITLE
Fix `scan_entity()` to not choke on missing namespace in schema def

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 .Rhistory
 .RData
 .Ruserdata
+.Rbuildignore
+*.Rproj

--- a/R/entity-schema.R
+++ b/R/entity-schema.R
@@ -193,7 +193,7 @@ scan_entity = function(pkgEnv, entitynm, con){
                                                 con = con,
                                                 namespace = namespace)
   array = paste0(namespace, ".", entitynm)
-  if(permissions$l & !permissions$r & pkgEnv$meta$L$namespace[[namespace]]$is_secured){
+  if(permissions$l && !permissions$r && pkgEnv$meta$L$namespace[[namespace]]$is_secured){
     if(con$aop_connection$scidb_version()$major>=21){
       array = paste0("secure_scan(",array,", strict:false)")
     } else {


### PR DESCRIPTION
This fixes https://github.com/Paradigm4/revealcore/issues/6